### PR TITLE
[Fix] - Format issues in @hotmail/@outlook emails.

### DIFF
--- a/Sources/SMTPKitten/SMTPOutbound.swift
+++ b/Sources/SMTPKitten/SMTPOutbound.swift
@@ -33,7 +33,7 @@ final class SMTPClientOutboundHandler: MessageToByteEncoder {
             for header in mail.headers {
                 headersText += "\(header.key): \(header.value)\r\n"
             }
-            headersText += "Content-Type: text/plain; charset=\"utf-8\"\r\n"
+            headersText += "Content-Type: \(mail.contentType.rawValue); charset=\"utf-8\"\r\n"
             headersText += "Content-Transfer-Encoding: 7bit\r\n"
             out.writeString(headersText)
             out.writeString("\r\n\(mail.text)\r\n.")


### PR DESCRIPTION
Line 36 overrides the setting selected in the "Mail" class and this causes formatting problems in emails sent to @ hotmail / @ outlook domains.