### PR TITLE
Add support for custom headers

### DIFF
--- a/Sources/SMTPKitten/Mail.swift
+++ b/Sources/SMTPKitten/Mail.swift
@@ -102,11 +102,16 @@ public struct Mail {
     /// The text of the mail. This can be either plain text or HTML depending on the `contentType` property.
     public var content: Content
     
+    /// Adds custom headers and overwrites the implicitly created ones. Use this property to add headers relevant for sending bulk emails, such as `List-Unsubscribe` or `Precedence` headers.
+    public var customHeaders: [String: String]
+    
     /// Creates a new `Mail` instance.
     public init(
         from: MailUser,
         to: Set<MailUser>,
         cc: Set<MailUser> = [],
+        bcc: Set<MailUser> = [],
+        customHeaders: [String: String] = [:],
         subject: String,
         content: Content
     ) {
@@ -114,7 +119,8 @@ public struct Mail {
         self.from = from
         self.to = to
         self.cc = cc
-        self.bcc = []
+        self.bcc = bcc
+        self.customHeaders = customHeaders
         self.subject = subject
         self.content = content
     }
@@ -123,6 +129,8 @@ public struct Mail {
         from: MailUser,
         to: Set<MailUser>,
         cc: Set<MailUser> = [],
+        bcc: Set<MailUser> = [],
+        customHeaders: [String: String] = [:],
         subject: String,
         @MailBodyBuilder content: () -> Content
     ) {
@@ -130,7 +138,8 @@ public struct Mail {
         self.from = from
         self.to = to
         self.cc = cc
-        self.bcc = []
+        self.bcc = bcc
+        self.customHeaders = customHeaders
         self.subject = subject
         self.content = content()
     }
@@ -162,6 +171,10 @@ public struct Mail {
             headers["Subject"] = "=?utf-8?B?\(data.base64EncodedString())?="
         } else {
             headers["Subject"] = subject
+        }
+        
+        for header in customHeaders {
+            headers[header.key] = header.value
         }
         
         return headers

--- a/Tests/SMTPKittenTests/SMTPKittenTests.swift
+++ b/Tests/SMTPKittenTests/SMTPKittenTests.swift
@@ -68,9 +68,9 @@ final class SMTPKittenTests: XCTestCase {
         let attachment = try Data(contentsOf: URL(filePath: attachmentPath))
 
         var contents: [MailContentConvertible] = [
-            "Welcome to our app, you're all set up & stuff."
-            Mail.Image.png(image, filename: "Screenshot.png")
-            Mail.Content.alternative("**End** of mail btw.", html: "<b>End</b> of mail btw.")
+            "Welcome to our app, you're all set up & stuff.",
+            Mail.Image.png(image, filename: "Screenshot.png"),
+            Mail.Content.alternative("**End** of mail btw.", html: "<b>End</b> of mail btw."),
             Mail.Attachment(attachment, mimeType: "application/pdf")
         ]
         
@@ -97,9 +97,4 @@ final class SMTPKittenTests: XCTestCase {
         
         try await client.sendMail(mail)
     }
-    
-    static var allTests = [
-        ("testExample", testExample),
-        ("testMutableContentExample", testMutableContentExample),
-    ]
 }

--- a/Tests/SMTPKittenTests/XCTestManifests.swift
+++ b/Tests/SMTPKittenTests/XCTestManifests.swift
@@ -1,9 +1,0 @@
-import XCTest
-
-#if !canImport(ObjectiveC)
-public func allTests() -> [XCTestCaseEntry] {
-    return [
-        testCase(SMTPKittenTests.allTests),
-    ]
-}
-#endif


### PR DESCRIPTION
This allows to pass custom headers. A common use case would be adding `List-Unsubscribe` header when sending bulk emails.