### PR TITLE
Mail User nil default for name field

### DIFF
--- a/Sources/SMTPKitten/Types/MailUser.swift
+++ b/Sources/SMTPKitten/Types/MailUser.swift
@@ -6,7 +6,8 @@ public struct MailUser: Hashable, Sendable {
     /// The user's email address.
     public let email: String
 
-    public init(name: String?, email: String) {
+    /// A new mail user with an optional name.
+    public init(name: String? = nil, email: String) {
         self.name = name
         self.email = email
     }


### PR DESCRIPTION
Added a default nil value for a mail user's name when none is available.