### PR TITLE
Enhance commandFailed case with detail parameter

### DIFF
--- a/Sources/SMTPKitten/Connection/Errors.swift
+++ b/Sources/SMTPKitten/Connection/Errors.swift
@@ -2,6 +2,6 @@ enum SMTPConnectionError: Error {
     case endOfStream
     case protocolError
     case startTLSFailure
-    case commandFailed(code: Int)
+    case commandFailed(code: Int, detail: String)//undev4 - added the detail
     case loginFailed
 }


### PR DESCRIPTION
Added a detail parameter to the commandFailed case in the SMTPConnectionError enum, this helps understand what the actual error is